### PR TITLE
Alterações no arquivo default do nginx

### DIFF
--- a/5.5/nginx-default.conf
+++ b/5.5/nginx-default.conf
@@ -9,7 +9,7 @@ server {
   server_name localhost;
 
   location / {
-    try_files $uri $uri/ /index.php;
+    try_files $uri $uri/ /index.php?$query_string;
   }
 
   location ~ \.php$ {

--- a/5.6/nginx-default.conf
+++ b/5.6/nginx-default.conf
@@ -9,7 +9,7 @@ server {
   server_name localhost;
 
   location / {
-    try_files $uri $uri/ /index.php;
+    try_files $uri $uri/ /index.php?$query_string;
   }
 
   location ~ \.php$ {


### PR DESCRIPTION
Adicionado o parâmetro $query_string no arquivo default do nginx, pois
variáveis de url (ex.: url?var=value) não estavam sendo enviadas
corretamente para as aplicações (testado com uma aplicação Laravel)
